### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,7 +2,7 @@
 CHANGES
 =======
 
-5.2 (unreleased)
+6.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ CHANGES
 6.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 5.1 (2025-07-25)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '5.2.dev0'
+version = '6.0.dev0'
 
 
 def read(*rnames):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -63,9 +62,6 @@ setup(name='zope.app.basicskin',
       ],
       url='https://github.com/zopefoundation/zope.app.basicskin',
       license='ZPL-2.1',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope', 'zope.app'],
       python_requires='>=3.9',
       install_requires=['setuptools',
                         'zope.component',
@@ -75,7 +71,7 @@ setup(name='zope.app.basicskin',
       extras_require=dict(
           test=[
               'zope.component [test]',
-              'zope.testrunner',
+              'zope.testrunner >= 6.4',
           ]),
       include_package_data=True,
       zip_safe=False,

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover

--- a/src/zope/app/__init__.py
+++ b/src/zope/app/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
